### PR TITLE
Switch Centos to cmake3

### DIFF
--- a/docker/centos6/Dockerfile
+++ b/docker/centos6/Dockerfile
@@ -19,7 +19,7 @@ ENV LC_ALL="en_US.UTF-8" LANG="en_US.UTF-8"
 ENV PATH /usr/bin:/usr/sbin:/bin:/sbin
 
 # Install dependencies to speed up builds
-RUN yum -y install cmake readline-devel libyaml-devel binutils-devel \
+RUN yum -y install cmake3 readline-devel libyaml-devel binutils-devel \
                    zlib-devel doxygen perl-Test-Harness
 RUN yum -y install python-pip python-devel python-daemon python-yaml \
                    python-msgpack python-gevent python-six python-sphinx

--- a/docker/centos7/Dockerfile
+++ b/docker/centos7/Dockerfile
@@ -13,7 +13,7 @@ ENV LC_ALL="en_US.UTF-8" LANG="en_US.UTF-8"
 ENV PATH /usr/bin:/usr/sbin:/bin:/sbin
 
 # Install dependencies to speed up builds
-RUN yum -y install cmake readline-devel libyaml-devel binutils-devel \
+RUN yum -y install cmake3 readline-devel libyaml-devel binutils-devel \
                    zlib-devel doxygen perl-Test-Harness
 RUN yum -y install python-pip python-devel python-daemon python-yaml \
                    python-msgpack python-gevent python-six python-sphinx


### PR DESCRIPTION
Centos 6/7 have an old 2.x cmake, which is out of date for many builds.

cmake3 is available in EPEL 