### PR TITLE
Fix link to package cloud integration in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ notifications:
 
 ```
 
-Enable [Travis integration] and [Packagecloud integration ] and then push
+Enable [Travis integration] and [Packagecloud integration] and then push
 changes to [GitHub].
 
 N.B. Now we build packages only for master branch (or for stuff hardcoded in


### PR DESCRIPTION
Just a random space that messed up the markdown link.