### PR TITLE
Fix for handling /Users local home dir on linux images

### DIFF
--- a/build
+++ b/build
@@ -106,6 +106,7 @@ $(BUILDROOT)/%/Dockerfile:
 	@echo "Generating Dockerfile"
 	@echo "-------------------------------------------------------------------"
 	@echo "FROM $(DOCKER_REPO):$(call osdist,$@)" > $@.tmp
+	@echo "RUN mkdir -p $$(dirname $${HOME})" >> $@.tmp
 	@echo "RUN useradd -s $${SHELL} -u $$(id -u) -d $${HOME} $${USER}" >> $@.tmp
 	@echo "RUN usermod -a -G wheel $${USER} || :;\\" >> $@.tmp
 	@echo "    usermod -a -G adm $${USER} || :;\\" >> $@.tmp


### PR DESCRIPTION
I'm trying to use the native Docker solution rather than a VM. Consequently, the `$HOME` var is `/Users/username`, but `/Users` doesn't exist and `useradd` fails. By injecting a `mkdir`, if the dir exists, it should continue without issue. If it doesn't, it will be created and things will move along smoothly.