### PR TITLE
Debian arch build fix

### DIFF
--- a/build
+++ b/build
@@ -175,7 +175,7 @@ $(BUILDROOT)/rpm-%/results/.done: $(BUILDROOT)/rpm-%/$(PRODUCT).spec \
 # Copy debian/ to buildroot/$OS-$DIST
 $(BUILDROOT)/deb-%/debian/changelog: debian/changelog
 	@mkdir -p $(abspath $(dir $@)/../)
-	cp -fpR debian/ $(abspath $(dir $@)/../)
+	cp -fpR debian $(abspath $(dir $@)/../)
 
 # A rule to build DEB packages
 $(BUILDROOT)/deb-%/results/.done: $(BUILDROOT)/deb-%/debian/changelog \

--- a/pack/deb.mk
+++ b/pack/deb.mk
@@ -49,7 +49,7 @@ $(DEB_NAME)-$(RELEASE).dsc: $(NAME)/debian/changelog $(DEB_TARBALL)
 	sudo rm -rf /var/lib/apt/lists/*
 	sudo apt-get update > /dev/null
 	cd $(NAME) && sudo mk-build-deps -i --tool "apt-get -y" || :
-	cd $(NAME) && sudo rm -f *build-deps_*_all.deb
+	cd $(NAME) && sudo rm -f *build-deps_*.deb
 	@echo
 	@echo "-------------------------------------------------------------------"
 	@echo "Building packages"


### PR DESCRIPTION
This includes two fixes. 

The first is for when `cp` is called to put the debian directory into the working root dir. The problem is the trailing slash. From the man page explaining the `-R` option: `If the source_file ends in a /, the contents of the directory are copied rather than the directory itself.` Because of this, the debian dir wasn't being found and I was getting failures.

The second involves cleanup.  When building for a specific architecture, a file like `name-build-deps_version_amd64.deb` is created. Unfortunately, it doesn't get cleaned up since only `*build-deps*_all.deb` was deleted. This caused debian to bail complaining about binary file differences that it couldn't resolve (meaning it didn't know what to do with the .deb file). I changed this to delete all `*build-deps*.deb` files and that fixes the problem.